### PR TITLE
自動更新の実装

### DIFF
--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -4,7 +4,7 @@ $(function(){
 
     image = (message.image_url) ? `<img class="lower-message__image" src="${ message.image_url }">`: "";
 
-    var html = `<div class="message">
+    var html = `<div class="message" data-message-id="${message.id}">
                   <div class="upper-message">
                     <div class="upper-message__user-name">
                       ${message.user_name}
@@ -24,7 +24,6 @@ $(function(){
   }
 
   function scroll() {
-
     window.scroll(0,$(document).height());
   }
 
@@ -52,4 +51,29 @@ $(function(){
       $('.form__submit').prop('disabled', false);
     })
   });
+
+  // 自動更新 
+  var reloadMessages = function () {
+    if (location.href.match(/\/groups\/\d+\/messages/)){
+      var last_message_id = $('.message').filter(":last").data("message-id"); 
+      $.ajax({
+        url: location.href,
+        type: 'GET',
+        dataType: 'json',
+        data: {id: last_message_id}
+      })
+      .done(function (messages) {
+        var insertHTML = '';
+        messages.forEach(function (message) {
+          insertHTML = buildHTML(message);
+          $('.messages').append(insertHTML);
+        })
+        scroll();
+      })
+      .fail(function () {
+        alert('自動更新に失敗しました');
+      });
+    };
+  };
+  setInterval(reloadMessages, 5000);
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -2,6 +2,5 @@ class Api::MessagesController < ApplicationController
   def index
     @group = Group.find(params[:group_id]) 
     @messages = @group.messages.includes(:user).where('id > ?', params[:id])
-    binding.pry
   end
 end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    @group = Group.find(params[:group_id]) 
+    @messages = @group.messages.includes(:user).where('id > ?', params[:id])
+    binding.pry
+  end
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{"data-message-id": "#{message.id}"}
   .upper-message
     .upper-message__user-name
       = message.user.name

--- a/app/views/messages/index.json.jbuilder
+++ b/app/views/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content      message.content
+  json.image_url        message.image.url
+  json.created_at         message.created_at.strftime("%Y/%m/%d %H:%M")
+  json.user_name    message.user.name
+  json.id           message.id
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
# WHAT
チャットが自動で更新されるようにする。

# WHY
現在自分が投稿した場合は、非同期通信で画面に投稿したメッセージが表示されるが、別のユーザーが別の画面から投稿したメッセージはリロードしなければ表示されない。これではチャットとは言えないので、自動でチャット画面が更新されるようにする。